### PR TITLE
Us897 remove input too short

### DIFF
--- a/scripts/ontoportal.js
+++ b/scripts/ontoportal.js
@@ -8,7 +8,7 @@ jQuery(document).ready(function ($) {
     const translations = {
         en: {
             selectTitle: "Open in new tab to view Term page",
-            placeholder: "Search by preferred or alternate label",
+            placeholder: "Type one or more words",
             searching: "Searching...",
             freeTextPrefix: "Free text: ",
             expandFields: "Expand all fields",
@@ -16,7 +16,7 @@ jQuery(document).ready(function ($) {
         },
         fr: {
             selectTitle: "Ouvre la page du mot-clé dans un nouvel onglet",
-            placeholder: "Recherchez par mot-clé exact ou synonyme",
+            placeholder: "Taper un ou plusieurs mots",
             searching: "Recherche en cours...",
             freeTextPrefix: "Saisie libre: ",
             expandFields: "Développer tous les champs",

--- a/scripts/ontoportal.js
+++ b/scripts/ontoportal.js
@@ -265,7 +265,11 @@ jQuery(document).ready(function ($) {
                         searching: function (params) {
                             // Change this to be appropriate for your application
                             return getLocalizedText("searchBy");
-                        }
+                        },
+                        inputTooShort: function(args) {
+                            //return "Please enter " + args.minimum + " or more characters";
+                            return '';
+                        },
                     },
                     placeholder: placeholder,
                     // Some vocabs are very slow and/or fail with a 500 error when searching for only 2 letters

--- a/scripts/ontoportal.js
+++ b/scripts/ontoportal.js
@@ -8,16 +8,16 @@ jQuery(document).ready(function ($) {
     const translations = {
         en: {
             selectTitle: "Open in new tab to view Term page",
-            selectTerm: "Select a term",
-            searchBy: "Search by preferred or alternate label...",
+            placeholder: "Search by preferred or alternate label",
+            searching: "Searching...",
             freeTextPrefix: "Free text: ",
             expandFields: "Expand all fields",
             shrinkFields: "Shrink all fields",
         },
         fr: {
             selectTitle: "Ouvre la page du mot-clé dans un nouvel onglet",
-            selectTerm: "Tapez le mot-clé",
-            searchBy: "Recherchez par mot-clé exact ou synonyme",
+            placeholder: "Recherchez par mot-clé exact ou synonyme",
+            searching: "Recherche en cours...",
             freeTextPrefix: "Saisie libre: ",
             expandFields: "Développer tous les champs",
             shrinkFields: "Réduire tous les champs",
@@ -176,7 +176,7 @@ jQuery(document).ready(function ($) {
                 let vocabUriSelector = `input[data-cvoc-managed-field="${managedFields["vocabularyUri"]}"]`;
                 let termSelector = `input[data-cvoc-managed-field="${managedFields["termName"]}"]`;
 
-                let placeholder = input.hasAttribute("data-cvoc-placeholder") ? $(input).attr("data-cvoc-placeholder") : getLocalizedText("selectTerm");
+                let placeholder = input.hasAttribute("data-cvoc-placeholder") ? $(input).attr("data-cvoc-placeholder") : getLocalizedText("placeholder");
                 let termParentUri = $(input).data("cvoc-filter");
                 // <select> identifier
                 let selectId = "ontoportalAddSelect_" + num;
@@ -264,10 +264,10 @@ jQuery(document).ready(function ($) {
                     language: {
                         searching: function (params) {
                             // Change this to be appropriate for your application
-                            return getLocalizedText("searchBy");
+                            return getLocalizedText("searching");
                         },
                         inputTooShort: function(args) {
-                            //return "Please enter " + args.minimum + " or more characters";
+                            //return "Please enter " + (e.minimum - e.input.length) + " or more characters";
                             return '';
                         },
                     },


### PR DESCRIPTION
- [x]  "Please enter 3 or more characters" a été retiré comme demandé laissant place à un affichage de message étrange que j'ai corrigé dans les items suivants;

- [x] Modification du message de "chargement" : meilleur expérience utilisateur
- [x] Modification du message pour le placeholder plus cohérent par rapport à "Afin de ne pas être mis en erreur alors qu'il faut entrer des mots entiers."
- [ ] Reste à voir si on veut corriger la clé EN `Search by preferred or alternate label` en `Search by exact term or alternate label`